### PR TITLE
163147597 catch 502 and retry

### DIFF
--- a/cass_client_ruby.gemspec
+++ b/cass_client_ruby.gemspec
@@ -1,10 +1,10 @@
 Gem::Specification.new do |s|
   s.name        = 'cass-fmadata-client'
-  s.version     = '1.0.2'
-  s.date        = '2018-08-21'
+  s.version     = '1.0.3'
+  s.date        = '2019-01-22'
   s.summary     = 'Client for CASS API'
   s.description = 'Client for CASS API'
-  s.authors     = ['Brian Long', 'Marta Wójtowicz']
+  s.authors     = ['Brian Long', 'Marta Wójtowicz', 'Paweł Jermalonek']
   s.email       = 'brian.long@firstmoversadvantage.com'
   s.files       = ['lib/cass_fmadata_client.rb',
                    'lib/cass_fmadata_client/base.rb',

--- a/lib/cass_fmadata_client.rb
+++ b/lib/cass_fmadata_client.rb
@@ -6,4 +6,5 @@ require 'json'
 
 module CassFma
   class Client < CassClient::Base; end
+  class BadResponseError < StandardError; end
 end

--- a/lib/cass_fmadata_client/base.rb
+++ b/lib/cass_fmadata_client/base.rb
@@ -50,21 +50,28 @@ module CassClient
         use_ssl: uri.scheme == "https",
       }
 
+      # set try_number for retry logic
       try_number = 0
       begin
         Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
           response = http.request(request)
+
+          # raise error if the response is other than Success
           raise CassFma::BadResponseError, response.class.name unless response.kind_of? Net::HTTPSuccess
           response
         end
       rescue CassFma::BadResponseError => e
         try_number += 1
+
+        # raise an error if max retries reached - it's neccessary to inform a client that there
+        # still is some issue
         raise update_error_message(e) and return if try_number > @max_retries
         sleep @retry_interval
         retry
       end
     end
 
+    # Add some more specifically info to error message
     def update_error_message(e)
       e.message << ' (MAX_RETRIES reached)'
       e

--- a/lib/cass_fmadata_client/connection.rb
+++ b/lib/cass_fmadata_client/connection.rb
@@ -6,10 +6,15 @@ module CassClient
 
     DEFAULT_URL     = 'www.example.com'.freeze
     DEFAULT_VERSION = '/api'.freeze
+    # retry logic defaults:
+    DEFAULT_MAX_RETRIES = 5
+    DEFAULT_RETRY_INTERVAL = 5
 
     def setup_connection(p = {})
-      @host  = p[:host] || DEFAULT_URL
-      @token = p[:token]
+      @host           = p[:host]            || DEFAULT_URL
+      @token          = p[:token]
+      @max_retries    = p[:max_retries]     || DEFAULT_MAX_RETRIES
+      @retry_interval = p[:retry_interval]  || DEFAULT_RETRY_INTERVAL
     end
 
     def headers

--- a/lib/cass_fmadata_client/connection.rb
+++ b/lib/cass_fmadata_client/connection.rb
@@ -8,7 +8,8 @@ module CassClient
     DEFAULT_VERSION = '/api'.freeze
     # retry logic defaults:
     DEFAULT_MAX_RETRIES = 5
-    DEFAULT_RETRY_INTERVAL = 5
+    # retry interval in seconds
+    DEFAULT_RETRY_INTERVAL = 3
 
     def setup_connection(p = {})
       @host           = p[:host]            || DEFAULT_URL
@@ -27,5 +28,4 @@ module CassClient
       URI.parse(@host).to_s
     end
   end
-
 end

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,26 @@
+#### What's this PR do?
+- Allows the system to associate customers and users
+
+#### Where should the reviewer start?
+  test/integration/associate_customer_account_test.rb
+
+#### How should this be manually tested?
+- Click on the Assign to User button on the customer account
+- Select a user
+- The Customer Account should now show on the User's info page
+
+#### Any background context you want to provide?
+N/A
+
+#### What are the relevant tickets?
+Tracker 108108922
+
+#### Screenshots (if appropriate)
+
+#### Definition of Done:
+- [N] Is there appropriate test coverage?
+- [N] Does this PR have any migrations?
+- [N] Are there changes to specification in the form of changes to tests
+- [N] Does this add new dependencies?
+- [N] Will this feature require a new piece of infrastructure be implemented?
+- [N] Are the controllers secure?

--- a/test/test_cass_client.rb
+++ b/test/test_cass_client.rb
@@ -7,6 +7,7 @@ require 'pry'
 require 'webmock'
 include WebMock::API
 WebMock.disable_net_connect!(allow_localhost: true)
+# Stubbing requests works with ruby 2.2.4 (I had troubles with other versions)
 
 class CassClientTest < Minitest::Test
   def test_initialize_cass_client
@@ -146,7 +147,7 @@ class CassClientTest < Minitest::Test
   end
 
 
-  def test_retry_logic_bat_gateway
+  def test_retry_logic_bad_gateway
     client = CassFma::Client.new(host:  ENV['CASS_URL'],
                                  token: ENV['CASS_TOKEN'],
                                  max_retries: 3,

--- a/test/test_cass_client.rb
+++ b/test/test_cass_client.rb
@@ -119,4 +119,55 @@ class CassClientTest < Minitest::Test
     response = client.address(params)
     assert_equal response.code, '200'
   end
+
+  def test_retry_logic_service_unavailable
+    client = CassFma::Client.new(host:  ENV['CASS_URL'],
+                                 token: ENV['CASS_TOKEN'],
+                                 max_retries: 3,
+                                 retry_interval: 1)
+
+    params =  { "city": "Boulder",
+                "state": "CO",
+                "street_address": "2950 N Lakeridge Trl",
+                "zip": "80302" }
+
+    stub_request(:get, ENV['CASS_URL'] + 'address/?city=Boulder&state=CO&street_address=2950+N+Lakeridge+Trl&zip=80302').
+      with(headers: {'Accept':          '*/*',
+                     'Accept-Encoding': 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                     'Token':           ENV['CASS_TOKEN'],
+                     'User-Agent':      'Ruby'}).
+      to_return(status: 503, body: "", headers: {})
+
+    error = assert_raises CassFma::BadResponseError do
+      client.address(params)
+    end
+
+    assert_equal 'Net::HTTPServiceUnavailable (MAX_RETRIES reached)', error.message
+  end
+
+
+  def test_retry_logic_bat_gateway
+    client = CassFma::Client.new(host:  ENV['CASS_URL'],
+                                 token: ENV['CASS_TOKEN'],
+                                 max_retries: 3,
+                                 retry_interval: 1)
+
+    params =  { "city": "Boulder",
+                "state": "CO",
+                "street_address": "2950 N Lakeridge Trl",
+                "zip": "80302" }
+
+    stub_request(:get, ENV['CASS_URL'] + 'address/?city=Boulder&state=CO&street_address=2950+N+Lakeridge+Trl&zip=80302').
+      with(headers: {'Accept':          '*/*',
+                     'Accept-Encoding': 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+                     'Token':           ENV['CASS_TOKEN'],
+                     'User-Agent':      'Ruby'}).
+      to_return(status: 502, body: "Bad Gateway", headers: {})
+
+    error = assert_raises CassFma::BadResponseError do
+      client.address(params)
+    end
+
+    assert_equal 'Net::HTTPBadGateway (MAX_RETRIES reached)', error.message
+  end
 end


### PR DESCRIPTION
#### What's this PR do?
- Adds retry logic to cass-fmadata-client gem

 #### Where should the reviewer start?
- test/test_cass_client.rb

 #### How should this be manually tested?
- Use test with stubbed reponses

 #### Any background context you want to provide?
- Client initializer accepts params for retry_logic:
   - :max_retries - number of retry attempts
   - :retry_interval - interval in seconds between retries

 #### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/163147597

 #### Screenshots (if appropriate)

 #### Definition of Done:
- [Y] Is there appropriate test coverage?
- [N] Does this PR have any migrations?
- [N] Are there changes to specification in the form of changes to tests
- [N] Does this add new dependencies?
- [N] Will this feature require a new piece of infrastructure be implemented?
- [N] Are the controllers secure?