### PR TITLE
163620964 Add retry logic

### DIFF
--- a/lib/cass_fmadata_client.rb
+++ b/lib/cass_fmadata_client.rb
@@ -6,4 +6,5 @@ require 'json'
 
 module CassFma
   class Client < CassClient::Base; end
+  class BadResponseError < StandardError; end
 end

--- a/lib/cass_fmadata_client/base.rb
+++ b/lib/cass_fmadata_client/base.rb
@@ -41,7 +41,7 @@ module CassClient
 
       try_number = 0
       begin
-        res = start(uri.host, uri.port, :use_ssl => true) do |http|
+        start(uri.host, uri.port, :use_ssl => true) do |http|
           response = http.request(req)
 
           # raise error if the response is other than Success
@@ -76,6 +76,12 @@ module CassClient
       end
 
       http.start(&block)
+    end
+
+    # Add some more specific info to error message
+    def update_error_message(e)
+      e.message << ' (MAX_RETRIES reached)'
+      e
     end
 
     def tiger_url

--- a/lib/cass_fmadata_client/connection.rb
+++ b/lib/cass_fmadata_client/connection.rb
@@ -6,10 +6,16 @@ module CassClient
 
     DEFAULT_URL     = 'www.example.com'.freeze
     DEFAULT_VERSION = '/api'.freeze
+    # retry logic defaults:
+    DEFAULT_MAX_RETRIES = 5
+    # retry interval in seconds
+    DEFAULT_RETRY_INTERVAL = 3
 
     def setup_connection(p = {})
       @host  = p[:host] || DEFAULT_URL
       @token = p[:token]
+      @max_retries    = p[:max_retries]    || DEFAULT_MAX_RETRIES
+      @retry_interval = p[:retry_interval] || DEFAULT_RETRY_INTERVAL
     end
 
     def headers


### PR DESCRIPTION
Remove redundant request

#### What's this PR do?
- Retries requests to cass if they are not successful

#### Where should the reviewer start?
lib/cass_fmadata_client/base.rb

#### How should this be manually tested?
Ok this is tricky. You need to mock the requests so that it returns something else than 200. You could point the cass URI to some random website which will return 404. I took different approach and did something like this:
* create an endpoint inside red that returns 502 status code
* point cass uri to localhost
* remove ssl from requests in cass-fmadata-client gem
* copy cass-fmadata-client gem into directory of red project, copy it inside Dockerfile so it's available for the app and point cass-fmadata-client gem in Gemfile of red to this path
* create a property and observe what happens
* jump out of the window due to the complexity of this approach

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
https://www.pivotaltracker.com/story/show/163620964

#### Screenshots (if appropriate)

#### Definition of Done:
- [N] Is there appropriate test coverage?
- [N] Does this PR have any migrations?
- [N] Are there changes to specification in the form of changes to tests
- [N] Does this add new dependencies?
- [N] Will this feature require a new piece of infrastructure be implemented?
- [N] Are the controllers secure?
